### PR TITLE
Mkhaitman

### DIFF
--- a/inferno/lib/reader.py
+++ b/inferno/lib/reader.py
@@ -77,6 +77,7 @@ def dynamic_reader(stream, size=None, url=None, params=None):
     else:
         reader = csv.reader(stream, dialect=dialect)
 
+    done = False
     for line in stream:
         if line.find('{') != -1:
             try:
@@ -89,7 +90,6 @@ def dynamic_reader(stream, size=None, url=None, params=None):
                 yield parts
         else:
             # We couldn't find '{' in the line so it is not json encoded... use csv reader!
-            done = False
             while not done:
                 try:
                     if not line:
@@ -108,3 +108,5 @@ def dynamic_reader(stream, size=None, url=None, params=None):
                     # just skip bad lines
                     print 'csv line error: %s' % ee
                 line = reader.next()
+        if done:
+            break

--- a/inferno/lib/reader.py
+++ b/inferno/lib/reader.py
@@ -55,3 +55,64 @@ def csv_reader(stream, size=None, url=None, params=None):
         except Exception as ee:
             # just skip bad lines
             print 'csv line error: %s' % ee
+
+
+def dynamic_reader(stream, size=None, url=None, params=None):
+    """ This reader uses parts of both json_reader and csv_reader...
+        It will attempt to json_read the stream, and if that fails, it will try to csv_read it instead
+        using the fieldnames/dialect/delimiter as used in the csv_reader.
+        This is helpful in cases where an inferno job has more than one source tag,
+        where one of them may be json encoded, while the other may be delimited by some character
+    """ 
+    import ujson
+    import csv
+    import __builtin__
+
+    fieldnames = getattr(params, 'csv_fields', None)
+    dialect = getattr(params, 'csv_dialect', 'excel')
+    delimiter = getattr(params, 'delimiter', None)
+
+    if delimiter:
+        reader = csv.reader(stream, delimiter=delimiter)
+    else:
+        reader = csv.reader(stream, dialect=dialect)
+
+    done = False
+    use_csv_reader = False
+
+    while not done:
+        if use_csv_reader:
+            try:
+                line = reader.next()
+                if not line:
+                    continue
+                if not fieldnames:
+                    fieldnames = [str(x) for x in range(len(line))]
+                parts = dict(__builtin__.map(None, fieldnames, line))
+                if None in parts:
+                    # remove extra data values
+                    del parts[None]
+                yield parts
+            except StopIteration as e:
+                done = True
+            except Exception as ee:
+                # just skip bad lines
+                print 'csv line error: %s' % ee
+        else:
+            for line in stream:
+                if line.find('{') != -1:
+                    try:
+                        parts = ujson.loads(line.rstrip())
+                        assert isinstance(parts, dict)
+                    except:
+                        # just skip bad lines
+                        print 'json line error: %r' % line
+                    else:
+                        yield parts
+                else:
+                    # We couldn't find '{' in the line so it is not json encoded... use csv reader!
+                    use_csv_reader = True
+                    break
+            if not use_csv_reader:
+                done = True
+

--- a/inferno/lib/rule.py
+++ b/inferno/lib/rule.py
@@ -12,6 +12,7 @@ from inferno.lib.disco_ext import sorted_iterator, json_output_stream
 from inferno.lib.map import keyset_map
 from inferno.lib.reader import csv_reader
 from inferno.lib.reader import json_reader
+from inferno.lib.reader import dynamic_reader
 from inferno.lib.reduce import keyset_reduce
 from inferno.lib.result import keyset_result
 
@@ -20,6 +21,7 @@ gzip_csv_stream = gzip_stream + (csv_reader,)
 gzip_json_stream = gzip_stream + (json_reader,)
 chunk_json_stream = chain_stream + (json_reader,)
 chunk_csv_stream = chain_stream + (csv_reader,)
+chunk_dynamic_stream = chain_stream + (dynamic_reader,)
 json_reduce_output_stream = (reduce_output_stream, json_output_stream)
 
 


### PR DESCRIPTION
Allows a single inferno job to have multiple source tag types where the data in one may be in a CSV format and the other being in JSON format. Requires csv_fields to be specified on the rule (as well as delimiter if not using the default).