### PR TITLE
Make starting the daemon explicit

### DIFF
--- a/inferno/bin/run.py
+++ b/inferno/bin/run.py
@@ -184,6 +184,13 @@ def _get_options(argv):
         default=None,
         help="resume a job using the mapresults of supplied module.job_id")
 
+    parser.add_argument(
+        "--daemon",
+        dest="run_daemon",
+        default=False,
+        action="store_true",
+        help="run inferno as a daemon")
+
     options = parser.parse_args(argv)
 
     if options.source_tags:
@@ -232,7 +239,7 @@ def _get_options(argv):
             message = "Could not open/process data file: %s %s"
             log.error(message, options.data_file, e)
 
-    return result
+    return result, parser
 
 
 def _get_settings(options):
@@ -268,7 +275,7 @@ def _setup_logging(settings):
 
 
 def main(argv=sys.argv):
-    options = _get_options(argv[1:])
+    options, parser = _get_options(argv[1:])
     settings = _get_settings(options)
 
     if options['example_rules']:
@@ -356,11 +363,15 @@ def main(argv=sys.argv):
             log.error(trace)
             exit(1)
 
-    else:
+    elif options['run_daemon']:
         # run inferno in 'daemon' mode
         from inferno.lib.daemon import InfernoDaemon
         setproctitle('inferno - master')
         InfernoDaemon(settings).start()
+
+    else:
+        # Display help when no options specified
+        parser.print_help()
 
 if __name__ == '__main__':
     main()

--- a/test/bin/test_run.py
+++ b/test/bin/test_run.py
@@ -18,7 +18,7 @@ def assert_dicts_equal(d1, d2):
 class TestOptions(object):
 
     def test_defaults(self):
-        options = _get_options([])
+        options, _ = _get_options([])
         expected = {
             'data_file': None,
             'parameters': [],
@@ -41,7 +41,8 @@ class TestOptions(object):
             'start_paused': False,
             'example_rules': None,
             'process_map': None,
-            'process_results': None
+            'process_results': None,
+            'run_daemon': False,
             }
         assert_dicts_equal(options, expected)
 
@@ -102,80 +103,80 @@ class TestOptions(object):
         self._assert_parameters('--parameters')
 
     def _assert_force(self, flag):
-        options = _get_options([flag])
+        options, _ = _get_options([flag])
         eq_(options['force'], True)
 
     def _assert_profile(self, flag):
-        options = _get_options([flag])
+        options, _ = _get_options([flag])
         eq_(options['profile'], True)
 
     def _assert_debug(self, flag):
-        options = _get_options([flag])
+        options, _ = _get_options([flag])
         eq_(options['debug'], True)
 
     def _assert_disco_debug(self, flag):
-        options = _get_options([flag])
+        options, _ = _get_options([flag])
         eq_(options['disco_debug'], True)
 
     def _assert_settings(self, flag):
-        options = _get_options([flag, 'path_to_settings_file'])
+        options, _ = _get_options([flag, 'path_to_settings_file'])
         eq_(options['settings_file'], 'path_to_settings_file')
 
     def _assert_rules_directory(self, flag):
-        options = _get_options([flag, 'path_to_rules_directory'])
+        options, _ = _get_options([flag, 'path_to_rules_directory'])
         eq_(options['rules_directory'], 'path_to_rules_directory')
 
     def _assert_day_range(self, flag):
-        options = _get_options([flag, '10'])
+        options, _ = _get_options([flag, '10'])
         eq_(options['day_range'], 10)
 
     def _assert_day_offset(self, flag):
-        options = _get_options([flag, '5'])
+        options, _ = _get_options([flag, '5'])
         eq_(options['day_offset'], 5)
 
     def _assert_day_start(self, flag):
-        options = _get_options([flag, '2012-12-01'])
+        options, _ = _get_options([flag, '2012-12-01'])
         eq_(options['day_start'], date(2012, 12, 1))
 
     def _assert_immediate_rule(self, flag):
-        options = _get_options([flag, 'some_module.some_rule'])
+        options, _ = _get_options([flag, 'some_module.some_rule'])
         eq_(options['immediate_rule'], 'some_module.some_rule')
 
     def _assert_result_tag(self, flag):
-        options = _get_options([flag, 'some_result_tag'])
+        options, _ = _get_options([flag, 'some_result_tag'])
         eq_(options['result_tag'], 'some_result_tag')
 
     def _assert_parameters(self, flag):
         # one param
-        options = _get_options([flag, 'some_param: some_value'])
+        options, _ = _get_options([flag, 'some_param: some_value'])
         eq_(options['some_param'], 'some_value')
 
         # many params
-        options = _get_options([
+        options, _ = _get_options([
             flag, 'some_param_1: some_value_1',
             flag, 'some_param_2: some_value_2'])
         eq_(options['some_param_1'], 'some_value_1')
         eq_(options['some_param_2'], 'some_value_2')
 
         # integer
-        options = _get_options([flag, 'some_int: 100'])
+        options, _ = _get_options([flag, 'some_int: 100'])
         eq_(options['some_int'], 100)
 
         # list of integers
-        options = _get_options([flag, 'some_int_list: [100, 200, 300,]'])
+        options, _ = _get_options([flag, 'some_int_list: [100, 200, 300,]'])
         eq_(options['some_int_list'], [100, 200, 300])
 
     def _assert_source_tags(self, flag):
         # one tag
-        options = _get_options([flag, 'tag1'])
+        options, _ = _get_options([flag, 'tag1'])
         eq_(options['source_tags'], ['tag1'])
 
         # many tags
-        options = _get_options([flag, 'tag1,tag2'])
+        options, _ = _get_options([flag, 'tag1,tag2'])
         eq_(options['source_tags'], ['tag1', 'tag2'])
 
     def _assert_server(self, flag):
-        options = _get_options([flag, 'some_server'])
+        options, _ = _get_options([flag, 'some_server'])
         eq_(options['server'], 'some_server')
 
 
@@ -183,24 +184,24 @@ class TestSettings(object):
 
     def test_get_settings(self):
         # settings default
-        options = _get_options(['-e', 'some_unknown_settings_file'])
+        options, _ = _get_options(['-e', 'some_unknown_settings_file'])
         settings = _get_settings(options)
         eq_(settings['server'], 'localhost')
 
         # options override
-        options = _get_options(['-s', 'some_server'])
+        options, _ = _get_options(['-s', 'some_server'])
         settings = _get_settings(options)
         eq_(settings['server'], 'some_server')
 
         # file override
         settings_file = self._create_settings_file()
-        options = _get_options(['-e', settings_file])
+        options, _ = _get_options(['-e', settings_file])
         settings = _get_settings(options)
         eq_(settings['server'], 'another_server')
 
         # server from -s trumps -e
         settings_file = self._create_settings_file()
-        options = _get_options(['-e', settings_file, '-s', 'some_server'])
+        options, _ = _get_options(['-e', settings_file, '-s', 'some_server'])
         settings = _get_settings(options)
         eq_(settings['server'], 'some_server')
 


### PR DESCRIPTION
Currently, if there are multiple hosts with inferno commands on them, typing just inferno will start the daemon and automatic processing of configured rules. This puts a stop to that and makes you explicitly tell inferno you want it to start the daemon.