### PR TITLE
add last_commit file for monitoring when a rule last completed

### DIFF
--- a/inferno/lib/daemon.py
+++ b/inferno/lib/daemon.py
@@ -63,6 +63,7 @@ def run_rule_async(rule_name, settings):
         if rule.retry:
             # Failed before, however, ran successfully this time. Clean up fail/retry files
             pid.clean_up(pid_dir, rule)
+        pid.create_last_complete(pid_dir, rule)
     finally:
         pid.remove_pid(pid_dir, rule)
         os._exit(0)

--- a/inferno/lib/pid.py
+++ b/inferno/lib/pid.py
@@ -38,6 +38,10 @@ def should_run(pid_dir, rule):
     return False
 
 
+def create_last_complete(pid_dir, rule):
+    Datefile(pid_dir, "%s.last_complete" % rule.name, timestamp=datetime.utcnow())
+
+
 def create_last_run(pid_dir, rule):
     Datefile(pid_dir, "%s.last_run" % rule.name, timestamp=datetime.utcnow())
 


### PR DESCRIPTION
the last_run file monitors when inferno last attempted to start a rule. This is nice for monitoring, but I would also like to be able to monitor when a rule last completed. This helps cover the case where a job is failing silently, or where there is an invalid pid file preventing the job from running.